### PR TITLE
Fix crash on not finding qualaroo bundle when used from cocoapods

### DIFF
--- a/Qualaroo/Extensions/Bundle.swift
+++ b/Qualaroo/Extensions/Bundle.swift
@@ -14,11 +14,8 @@ extension Bundle {
   /// Convenience way to get Qualaroo bundle.
   ///
   /// - Returns: Bundle used by Qualaroo Framework.
-  static func qualaroo() -> Bundle {
-    let bundle =
-        Bundle(identifier: "org.cocoapods.Qualaroo")
-            .map {$0.path(forResource: "Qualaroo", ofType: "bundle")}
-            .map { Bundle(path: $0!) }!!
-    return bundle
+  static func qualaroo() -> Bundle? {
+    guard let path = Bundle(for: Qualaroo.self).path(forResource: "Qualaroo", ofType: "bundle") else { return nil }
+    return Bundle(path: path)
   }
 }

--- a/Qualaroo/Network/FetchSurveys/FetchSurveysComposer.swift
+++ b/Qualaroo/Network/FetchSurveys/FetchSurveysComposer.swift
@@ -48,7 +48,7 @@ class FetchSurveysComposer {
   }
 
   private func versionQuery() -> [URLQueryItem] {
-    guard let version = Bundle.qualaroo().object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
+    guard let version = Bundle.qualaroo()?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
       return []
     }
     return [URLQueryItem(name: "sdk_version", value: version)]

--- a/Qualaroo/Network/SdkSession.swift
+++ b/Qualaroo/Network/SdkSession.swift
@@ -14,7 +14,7 @@ struct SdkSession {
   let osVersion = UIDevice.current.systemVersion
   let deviceModel = UIDevice.current.type
   let language: String = Locale.current.languageCode ?? "unknown"
-  let sdkVersion: String = Bundle.qualaroo().object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+  let sdkVersion: String = Bundle.qualaroo()?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
   let appId: String = Bundle.main.bundleIdentifier ?? "unknown"
   let resolution: String
   let deviceType: String

--- a/Qualaroo/Survey/Body/LeadGenForm/LeadGenViewBuilder.swift
+++ b/Qualaroo/Survey/Body/LeadGenForm/LeadGenViewBuilder.swift
@@ -16,7 +16,7 @@ class LeadGenViewBuilder {
                          answerHandler: SurveyAnswerHandler,
                          theme: Theme) -> LeadGenFormView? {
     guard
-      let nib = Bundle.qualaroo().loadNibNamed("LeadGenFormView",
+      let nib = Bundle.qualaroo()?.loadNibNamed("LeadGenFormView",
                                                owner: nil,
                                                options: nil),
       let view = nib.first as? LeadGenFormView else { return nil }
@@ -72,7 +72,7 @@ class LeadGenViewBuilder {
                            textDelegate: TextChangeListener,
                            theme: Theme) -> LeadGenFormCell? {
     guard
-      let nib = Bundle.qualaroo().loadNibNamed("LeadGenFormCell",
+      let nib = Bundle.qualaroo()?.loadNibNamed("LeadGenFormCell",
                                                owner: nil,
                                                options: nil),
       let view = nib.first as? LeadGenFormCell else { return nil }

--- a/Qualaroo/Survey/Body/Question/List/AnswerListView.swift
+++ b/Qualaroo/Survey/Body/Question/List/AnswerListView.swift
@@ -57,7 +57,7 @@ class AnswerListView: UIView {
     
     private func answerListView() -> AnswerListView {
       guard
-        let nib = Bundle.qualaroo().loadNibNamed("AnswerListView", owner: nil, options: nil),
+        let nib = Bundle.qualaroo()?.loadNibNamed("AnswerListView", owner: nil, options: nil),
         let view = nib.first as? AnswerListView else { return AnswerListView() }
       return view
     }

--- a/Qualaroo/Survey/Body/Question/List/Cell/SelectableView.swift
+++ b/Qualaroo/Survey/Body/Question/List/Cell/SelectableView.swift
@@ -58,7 +58,7 @@ class SelectableView: UIView {
     let viewModel: ViewModel
     lazy var view: SelectableView = {
       guard
-        let nib = Bundle.qualaroo().loadNibNamed("SelectableView", owner: nil, options: nil),
+        let nib = Bundle.qualaroo()?.loadNibNamed("SelectableView", owner: nil, options: nil),
         let view = nib.first as? SelectableView else { return SelectableView() }
       return view
     }()

--- a/Qualaroo/Survey/Body/Question/QuestionViewFactory.swift
+++ b/Qualaroo/Survey/Body/Question/QuestionViewFactory.swift
@@ -48,7 +48,7 @@ class QuestionViewFactory {
   
   private func npsQuestionView(with question: Question) -> AnswerNpsView? {
     guard
-      let nib = Bundle.qualaroo().loadNibNamed("AnswerNpsView", owner: nil, options: nil),
+      let nib = Bundle.qualaroo()?.loadNibNamed("AnswerNpsView", owner: nil, options: nil),
       let view = nib.first as? AnswerNpsView else { return nil }
     let responseBuilder = SingleSelectionAnswerResponseBuilder(question: question)
     let validator = AnswerNpsValidator(question: question)
@@ -67,7 +67,7 @@ class QuestionViewFactory {
   }
   private func textQuestionView(with question: Question) -> AnswerTextView? {
     guard
-      let nib = Bundle.qualaroo().loadNibNamed("AnswerTextView", owner: nil, options: nil),
+      let nib = Bundle.qualaroo()?.loadNibNamed("AnswerTextView", owner: nil, options: nil),
       let view = nib.first as? AnswerTextView else { return nil }
     let responseBuilder = AnswerTextResponseBuilder(question: question)
     let validator = AnswerTextValidator(question: question)
@@ -84,7 +84,7 @@ class QuestionViewFactory {
   }
   private func dropdownQuestionView(with question: Question) -> AnswerDropdownView? {
     guard
-      let nib = Bundle.qualaroo().loadNibNamed("AnswerDropdownView", owner: nil, options: nil),
+      let nib = Bundle.qualaroo()?.loadNibNamed("AnswerDropdownView", owner: nil, options: nil),
       let view = nib.first as? AnswerDropdownView else { return nil }
     let answers = question.answerList.map { $0.title }
     let responseBuilder = SingleSelectionAnswerResponseBuilder(question: question)
@@ -100,7 +100,7 @@ class QuestionViewFactory {
   }
   private func binaryQuestionView(with question: Question) -> AnswerBinaryView? {
     guard
-      let nib = Bundle.qualaroo().loadNibNamed("AnswerBinaryView", owner: nil, options: nil),
+      let nib = Bundle.qualaroo()?.loadNibNamed("AnswerBinaryView", owner: nil, options: nil),
       let view = nib.first as? AnswerBinaryView else { return nil }
     let responseBuilder = SingleSelectionAnswerResponseBuilder(question: question)
     let interactor = AnswerBinaryInteractor(responseBuilder: responseBuilder,

--- a/Qualaroo/Survey/CustomComponents/XibView.swift
+++ b/Qualaroo/Survey/CustomComponents/XibView.swift
@@ -10,7 +10,7 @@
 class XibView: UIView {
   override func awakeFromNib() {
     guard
-      let xib = Bundle.qualaroo().loadNibNamed(String(describing: type(of: self)),
+      let xib = Bundle.qualaroo()?.loadNibNamed(String(describing: type(of: self)),
                                                owner: self,
                                                options: nil),
       let views = xib as? [UIView],

--- a/QualarooTests/Network/FetchSurveysComposerSpec.swift
+++ b/QualarooTests/Network/FetchSurveysComposerSpec.swift
@@ -35,7 +35,7 @@ class FetchSurveysComposerSpec: QuickSpec {
                                               appId: "testName",
                                               environment: .production)
           let components = URLComponents(url: composer.url()!, resolvingAgainstBaseURL: false)!
-          let version = Bundle.qualaroo().object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+          let version = Bundle.qualaroo()?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
           let queryItems = [URLQueryItem(name: "sdk_version", value: version),
                             URLQueryItem(name: "client_app", value: "testName"),
                             URLQueryItem(name: "device_type", value: UIDevice.current.model),
@@ -47,7 +47,7 @@ class FetchSurveysComposerSpec: QuickSpec {
         it("should create basic info even without app name") {
           let composer = FetchSurveysComposer(siteId: "123123", deviceId: "1", environment: .production)
           let components = URLComponents(url: composer.url()!, resolvingAgainstBaseURL: false)!
-          let version = Bundle.qualaroo().object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+          let version = Bundle.qualaroo()?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
           let queryItems = [URLQueryItem(name: "sdk_version", value: version),
                             URLQueryItem(name: "device_type", value: UIDevice.current.model),
                             URLQueryItem(name: "os_version", value: UIDevice.current.systemVersion),


### PR DESCRIPTION
In our project we are using qualaroo by importing it as a cocoa pod.

We found this crash on an enterprise build, when trying to force unwrap while getting the Qualaroo bundle containing the xibs. It was working just fine in debug.
The crash seems to be related on using `Bundle(identifier:)` instead of `Bundle(for:)`. Probably it has to do with podspec file configuration (probably resource_bundles change, commit 66e8dde !?) and our build configuration, but checking around, the recommended way to get the bundle within a pod is `Bundle(for:)`, so this should be the fix.

Things to consider:
- tests are crashing (Bundle.qualaroo()) returns nil, both with 1.9.1 and my fix. Since it was already crashing, I didn't spend more time into it.
- swift demo does not work for me (does not recognise swift module Qualaroo). I didn't spent any time into it.
- I tried to isolate the issue in a separate project, but I was not able to reproduce. However our setup is rather complex, therefore needs more tweaking to be as accurate as possible.

Tooling:
Xcode 10.1
cocoapods 1.5.3
Swift 4.2