### PR TITLE
Fix fetch survey timer setup

### DIFF
--- a/Qualaroo/Network/FetchSurveys/FetchSurveysScheduler.swift
+++ b/Qualaroo/Network/FetchSurveys/FetchSurveysScheduler.swift
@@ -111,6 +111,5 @@ extension FetchSurveysScheduler: FetchSurveysProtocol {
   
   func fetchSurveys() {
     setNewTimer()
-    tryToSendRequest()
   }
 }

--- a/Qualaroo/Network/FetchSurveys/FetchSurveysScheduler.swift
+++ b/Qualaroo/Network/FetchSurveys/FetchSurveysScheduler.swift
@@ -72,7 +72,7 @@ class FetchSurveysScheduler {
   private func setNewTimer() {
     timer.invalidate()
     let time = Const.surveyFetchInterval
-    timer = Timer(timeInterval: time, target: self, selector: #selector(tryToSendRequest), userInfo: nil, repeats: true)
+    timer = Timer.scheduledTimer(timeInterval: time, target: self, selector: #selector(tryToSendRequest), userInfo: nil, repeats: true)
     timer.fire()
   }
 }


### PR DESCRIPTION
This patch:

- makes Qualaroo actually refetch data every 3600 seconds (see #10) and
- removes the duplicate requests which made the race conditions fixed by #11 particularly unstable.